### PR TITLE
Refine middleman payment flow

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-EMAIL_ADDRESS=asonrichardsgaming@gmail.com
-EMAIL_PASSWORD=iymyorxxeocotqqt

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GMAIL_ADDRESS=your_gmail@gmail.com
+GMAIL_APP_PASSWORD=your_app_password
+DISCORD_BOT_TOKEN=your_discord_token

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py
+python-dotenv


### PR DESCRIPTION
## Summary
- add missing `has_role` helper
- overhaul `PaymentControlView` with confirm and manual start buttons
- store middleman ID and cash tag
- send payment instructions after middleman submits tag
- clean up unused middleman code and improve email parsing

## Testing
- `python -m py_compile draft_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6869605f1a2c8325aad02fa508df5f40